### PR TITLE
Bugfix and Improve the details in OLEDDisplayUiState during transition

### DIFF
--- a/src/OLEDDisplayUi.cpp
+++ b/src/OLEDDisplayUi.cpp
@@ -429,15 +429,15 @@ void OLEDDisplayUi::drawIndicator() {
       switch (this->indicatorPosition){
         case TOP:
           y = 0 - (8 * indicatorFadeProgress);
-          x = (this->display->width() / 2) - frameStartPos + 12 * i;
+          x = (this->display->width() / 2) - frameStartPos + indicatorSpacing * i;
           break;
         case BOTTOM:
           y = (this->display->height() - 8) + (8 * indicatorFadeProgress);
-          x = (this->display->width() / 2) - frameStartPos + 12 * i;
+          x = (this->display->width() / 2) - frameStartPos + indicatorSpacing * i;
           break;
         case RIGHT:
           x = (this->display->width() - 8) + (8 * indicatorFadeProgress);
-          y = (this->display->height() / 2) - frameStartPos + 2 + 12 * i;
+          y = (this->display->height() / 2) - frameStartPos + 2 + indicatorSpacing * i;
           break;
         case LEFT:
         default:

--- a/src/OLEDDisplayUi.cpp
+++ b/src/OLEDDisplayUi.cpp
@@ -184,6 +184,7 @@ void OLEDDisplayUi::nextFrame() {
   if (this->state.frameState != IN_TRANSITION) {
     this->state.manuelControll = true;
     this->state.frameState = IN_TRANSITION;
+    this->state.transitionFrameTarget = getNextFrameNumber();
     this->state.ticksSinceLastStateSwitch = 0;
     this->lastTransitionDirection = this->state.frameTransitionDirection;
     this->state.frameTransitionDirection = 1;
@@ -261,6 +262,7 @@ void OLEDDisplayUi::tick() {
         if (this->state.ticksSinceLastStateSwitch >= this->ticksPerTransition){
           this->state.frameState = FIXED;
           this->state.currentFrame = getNextFrameNumber();
+          this->state.transitionFrameTarget = 0;
           this->state.ticksSinceLastStateSwitch = 0;
           this->nextFrameNumber = -1;
         }
@@ -339,10 +341,14 @@ void OLEDDisplayUi::drawFrame(){
 
        // Prope each frameFunction for the indicator Drawen state
        this->enableIndicator();
-       (this->frameFunctions[this->state.currentFrame])(this->display, &this->state, x, y);
+       this->state.transitionFrameRelationship = OUTGOING;
+       //Since we're IN_TRANSITION, draw the old frame in a sliding-out position
+       (this->frameFunctions[this->state.currentFrame])(this->display, &this->state, x, y); 
        drawenCurrentFrame = this->state.isIndicatorDrawen;
 
        this->enableIndicator();
+       this->state.transitionFrameRelationship = INCOMING;
+       //Since we're IN_TRANSITION, draw the mew frame in a sliding-in position
        (this->frameFunctions[this->getNextFrameNumber()])(this->display, &this->state, x1, y1);
 
        // Build up the indicatorDrawState
@@ -368,7 +374,9 @@ void OLEDDisplayUi::drawFrame(){
       // And set indicatorDrawState to "not known yet"
       this->indicatorDrawState = 0;
       this->enableIndicator();
-      (this->frameFunctions[this->state.currentFrame])(this->display, &this->state, 0, 0);
+      this->state.transitionFrameRelationship = NONE;
+      //Since we're not transitioning, just draw the current frame at the origin
+      (this->frameFunctions[this->state.currentFrame])(this->display, &this->state, 0, 0); 
       break;
   }
 }

--- a/src/OLEDDisplayUi.h
+++ b/src/OLEDDisplayUi.h
@@ -72,6 +72,11 @@ enum FrameState {
   FIXED
 };
 
+enum TransitionRelationship {
+  NONE,
+  INCOMING,
+  OUTGOING,
+};
 
 const uint8_t ANIMATION_activeSymbol[] PROGMEM = {
   0x00, 0x18, 0x3c, 0x7e, 0x7e, 0x3c, 0x18, 0x00
@@ -89,6 +94,8 @@ struct OLEDDisplayUiState {
 
   FrameState    frameState;
   uint8_t       currentFrame;
+  uint8_t       transitionFrameTarget;
+  TransitionRelationship transitionFrameRelationship;
 
   bool          isIndicatorDrawen;
 


### PR DESCRIPTION
To any `drawFrame` functions consuming the OLEDDisplayUiState passed in the function parameters, we are adding two fields
`transitionFrameTarget` is the id of the field being transitioned_in
`transitionFrameRelationship` determines whether the function being called is transitioning IN or OUT


The bug fix here seems to affect the spacing of the dots via `indicatorSpacing`

The usage of these new fields may be observed in meshtastic-device Screen.cpp: https://github.com/meshtastic/Meshtastic-device/pull/705/files#diff-b96a4f56a51e883757b872d9680d6191810ababf13895af4ae816bcb783e4e54R159