### PR TITLE
Enable selection of I2C wire interface on Pico RP2040 platform.

### DIFF
--- a/src/SH1106Wire.h
+++ b/src/SH1106Wire.h
@@ -72,7 +72,7 @@ class SH1106Wire : public OLEDDisplay {
       this->_address = _address;
       this->_sda = _sda;
       this->_scl = _scl;
-#if !defined(ARDUINO_ARCH_ESP32) & !defined(ARCH_RP2040)
+#if !defined(ARDUINO_ARCH_ESP32) && !defined(ARCH_RP2040)
       this->_wire = &Wire;
 #else
       this->_wire = (_i2cBus==I2C_ONE) ? &Wire : &Wire1;

--- a/src/SH1106Wire.h
+++ b/src/SH1106Wire.h
@@ -72,7 +72,7 @@ class SH1106Wire : public OLEDDisplay {
       this->_address = _address;
       this->_sda = _sda;
       this->_scl = _scl;
-#if !defined(ARDUINO_ARCH_ESP32)
+#if !defined(ARDUINO_ARCH_ESP32) & !defined(ARCH_RP2040)
       this->_wire = &Wire;
 #else
       this->_wire = (_i2cBus==I2C_ONE) ? &Wire : &Wire1;


### PR DESCRIPTION
Might fix also issue #2985 in firmware.
https://github.com/meshtastic/firmware/issues/2985