### PR TITLE
Fix wrong I2C number detection for ESP32C6 target

### DIFF
--- a/src/AutoOLEDWire.h
+++ b/src/AutoOLEDWire.h
@@ -94,6 +94,8 @@ class AutoOLEDWire : public OLEDDisplay {
       this->_scl = _scl;
 #if !defined(ARDUINO_ARCH_ESP32) && !defined(ARCH_RP2040)
       this->_wire = &Wire;
+#elif defined(CONFIG_IDF_TARGET_ESP32C6)
+      this->_wire = &Wire;
 #else
       this->_wire = (_i2cBus==I2C_ONE) ? &Wire : &Wire1;
 #endif

--- a/src/SH1106Wire.h
+++ b/src/SH1106Wire.h
@@ -80,6 +80,8 @@ class SH1106Wire : public OLEDDisplay {
       this->_scl = _scl;
 #if !defined(ARDUINO_ARCH_ESP32) && !defined(ARCH_RP2040)
       this->_wire = &Wire;
+#elif defined(CONFIG_IDF_TARGET_ESP32C6)
+      this->_wire = &Wire;
 #else
       this->_wire = (_i2cBus==I2C_ONE) ? &Wire : &Wire1;
 #endif

--- a/src/SSD1306Wire.h
+++ b/src/SSD1306Wire.h
@@ -80,6 +80,8 @@ class SSD1306Wire : public OLEDDisplay {
       this->_scl = _scl;
 #if !defined(ARDUINO_ARCH_ESP32)
       this->_wire = &Wire;
+#elif defined(CONFIG_IDF_TARGET_ESP32C6)
+      this->_wire = &Wire;
 #else
       this->_wire = (_i2cBus==I2C_ONE) ? &Wire : &Wire1;
 #endif


### PR DESCRIPTION
Error:
```
.pio/libdeps/seeed-xiao-esp32c6/ESP8266 and ESP32 OLED driver for SSD1306 displays/src/AutoOLEDWire.h: In constructor 'AutoOLEDWire::AutoOLEDWire(uint8_t, int, int, OLEDDISPLAY_GEOMETRY, HW_I2C, int)':
.pio/libdeps/seeed-xiao-esp32c6/ESP8266 and ESP32 OLED driver for SSD1306 displays/src/AutoOLEDWire.h:98:51: error: 'Wire1' was not declared in this scope; did you mean 'Wire'?
   98 |       this->_wire = (_i2cBus==I2C_ONE) ? &Wire : &Wire1;
      |                                                   ^~~~~
      |                                                   Wire
```

Related to https://github.com/meshtastic/firmware/pull/5421