### PR TITLE
Add delay_poweroff option

### DIFF
--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -1049,7 +1049,8 @@ void OLEDDisplay::sendInitCommands(void) {
   sendCommand(DISPLAYALLON_RESUME);
   sendCommand(NORMALDISPLAY);
   sendCommand(0x2e);            // stop scroll
-  sendCommand(DISPLAYON);
+  if (!delayPoweron)
+    sendCommand(DISPLAYON);
 }
 
 void inline OLEDDisplay::drawInternal(int16_t xMove, int16_t yMove, int16_t width, int16_t height, const uint8_t *data, uint16_t offset, uint16_t bytesInData) {

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -345,6 +345,8 @@ class OLEDDisplay : public Stream {
     uint8_t            *buffer_back;
     #endif
 
+    bool delayPoweron = false;
+
     // Set the correct height, width and buffer for the geometry
     void setGeometry(OLEDDISPLAY_GEOMETRY g, uint16_t width = 0, uint16_t height = 0);
 


### PR DESCRIPTION
In some cases, we may want to do additional initialization before turning the display on. This gives us that option.