### PR TITLE
Preserve base class 'Print' overloads (address warnings)

### DIFF
--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -329,6 +329,9 @@ class OLEDDisplay : public Stream {
     uint16_t getHeight(void);
 
     // Implement needed function to be compatible with Print class
+#ifdef ARDUINO
+    using Print::write;
+#endif
     size_t write(uint8_t c);
     size_t write(const char* s);
 


### PR DESCRIPTION
Fix warnings in ESP32-Arduino 3.x builds by inheriting from Arduino's `Print::write` when applicable.