### PR TITLE
Add getter functions for I2C screen speed

### DIFF
--- a/src/AutoOLEDWire.h
+++ b/src/AutoOLEDWire.h
@@ -57,7 +57,9 @@
 #define SH1106_SET_PUMP_MODE 0XAD
 #define SH1106_PUMP_ON 0X8B
 #define SH1106_PUMP_OFF 0X8A
+#ifndef AUTOOLEDI2C_FREQUENCY
 #define AUTOOLEDI2C_FREQUENCY 700000
+#endif
 //--------------------------------------
 
 class AutoOLEDWire : public OLEDDisplay {

--- a/src/AutoOLEDWire.h
+++ b/src/AutoOLEDWire.h
@@ -285,7 +285,7 @@ class AutoOLEDWire : public OLEDDisplay {
 
     // Get I2C speed
     virtual uint32_t getI2cFrequency() override {
-      return this->_frequency;
+      return this->_frequency < 0 ? 0U : static_cast<uint32_t>(this->_frequency);
     }
 
   private:

--- a/src/AutoOLEDWire.h
+++ b/src/AutoOLEDWire.h
@@ -57,6 +57,7 @@
 #define SH1106_SET_PUMP_MODE 0XAD
 #define SH1106_PUMP_ON 0X8B
 #define SH1106_PUMP_OFF 0X8A
+#define AUTOOLEDI2C_FREQUENCY 700000
 //--------------------------------------
 
 class AutoOLEDWire : public OLEDDisplay {
@@ -75,10 +76,10 @@ class AutoOLEDWire : public OLEDDisplay {
      * Create and initialize the Display using Wire library
      *
      * Beware for retro-compatibility default values are provided for all parameters see below.
-     * Please note that if you don't wan't SD1306Wire to initialize and change frequency speed ot need to 
+     * Please note that if you don't wan't SD1306Wire to initialize and change frequency speed ot need to
      * ensure -1 value are specified for all 3 parameters. This can be usefull to control TwoWire with multiple
      * device on the same bus.
-     * 
+     *
      * @param _address I2C Display address
      * @param _sda I2C SDA pin number, default to -1 to skip Wire begin call
      * @param _scl I2C SCL pin number, default to -1 (only SDA = -1 is considered to skip Wire begin call)
@@ -86,7 +87,7 @@ class AutoOLEDWire : public OLEDDisplay {
      * @param _i2cBus on ESP32 with 2 I2C HW buses, I2C_ONE for 1st Bus, I2C_TWO fot 2nd bus, default I2C_ONE
      * @param _frequency for Frequency by default Let's use ~700khz if ESP8266 is in 160Mhz mode, this will be limited to ~400khz if the ESP8266 in 80Mhz mode
      */
-    AutoOLEDWire(uint8_t _address, int _sda = -1, int _scl = -1, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64, HW_I2C _i2cBus = I2C_ONE, int _frequency = 700000) {
+    AutoOLEDWire(uint8_t _address, int _sda = -1, int _scl = -1, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64, HW_I2C _i2cBus = I2C_ONE, int _frequency = AUTOOLEDI2C_FREQUENCY) {
       setGeometry(g);
 
       this->_address = _address;
@@ -175,18 +176,18 @@ class AutoOLEDWire : public OLEDDisplay {
           sendCommand(COLUMNADDR);
           sendCommand(x_offset + minBoundX);
           sendCommand(x_offset + maxBoundX);
-  
+
           sendCommand(PAGEADDR);
           sendCommand(minBoundY);
           sendCommand(maxBoundY);
-  
+
           for (y = minBoundY; y <= maxBoundY; y++) {
             for (x = minBoundX; x <= maxBoundX; x++) {
               if (k == 0) {
                 _wire->beginTransmission(_address);
                 _wire->write(0x40);
               }
-  
+
               _wire->write(buffer[x + y * this->width()]);
               k++;
               if (k == (I2C_MAX_TRANSFER_BYTE - 1)) {
@@ -206,7 +207,7 @@ class AutoOLEDWire : public OLEDDisplay {
             minBoundXp2H = (minBoundX) & 0x0F;
             minBoundXp2L = 0x10 | ((minBoundX) >> 4 );
           }
-  
+
           for (y = minBoundY; y <= maxBoundY; y++) {
             sendCommand(0xB0 + y);
             sendCommand(minBoundXp2H);
@@ -239,10 +240,10 @@ class AutoOLEDWire : public OLEDDisplay {
           sendCommand(COLUMNADDR);
           sendCommand(x_offset);
           sendCommand(x_offset + (this->width() - 1));
-  
+
           sendCommand(PAGEADDR);
           sendCommand(0x0);
-  
+
           for (uint16_t i=0; i < displayBufferSize; i++) {
             _wire->beginTransmission(this->_address);
             _wire->write(0x40);
@@ -278,6 +279,11 @@ class AutoOLEDWire : public OLEDDisplay {
 
     void setDetected(uint8_t detected) {
       _detected = detected;
+    }
+
+    // Get I2C speed
+    virtual uint32_t getI2cFrequency() override {
+      return this->_frequency;
     }
 
   private:

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -165,11 +165,11 @@ class OLEDDisplay : public Stream {
 #endif
 
   public:
-	OLEDDisplay();
+	  OLEDDisplay();
     virtual ~OLEDDisplay();
 
-	uint16_t width(void) const { return displayWidth; };
-	uint16_t height(void) const { return displayHeight; };
+    uint16_t width(void) const { return displayWidth; };
+    uint16_t height(void) const { return displayHeight; };
 
     // Use this to resume after a deep sleep without resetting the display (what init() would do).
     // Returns true if connection to the display was established and the buffer allocated, false otherwise.
@@ -354,6 +354,9 @@ class OLEDDisplay : public Stream {
     // Set the correct height, width and buffer for the geometry
     void setGeometry(OLEDDISPLAY_GEOMETRY g, uint16_t width = 0, uint16_t height = 0);
 
+    // Get I2C Speed (to override)
+    virtual uint32_t getI2cFrequency() {return 0; }
+
   protected:
 
     OLEDDISPLAY_GEOMETRY geometry;
@@ -396,8 +399,6 @@ class OLEDDisplay : public Stream {
 
     uint16_t drawStringInternal(int16_t xMove, int16_t yMove, const char* text, uint16_t textLength, uint16_t textWidth, bool utf8);
 
-    // Get I2C Speed (to override)
-    virtual uint32_t getI2cFrequency() {return 0; }
 	FontTableLookupFunction fontTableLookupFunction;
 };
 

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -355,7 +355,8 @@ class OLEDDisplay : public Stream {
     void setGeometry(OLEDDISPLAY_GEOMETRY g, uint16_t width = 0, uint16_t height = 0);
 
     // Get I2C Speed (to override)
-    virtual uint32_t getI2cFrequency() {return 0; }
+    // Screens that don't set the speed, for any reason, they return 0
+    virtual uint32_t getI2cFrequency() { return 0; }
 
   protected:
 

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -297,7 +297,7 @@ class OLEDDisplay : public Stream {
     // normal brightness & contrast:  contrast = 100
     void setContrast(uint8_t contrast, uint8_t precharge = 241, uint8_t comdetect = 64);
 
-    // Convenience method to access 
+    // Convenience method to access
     virtual void setBrightness(uint8_t);
 
     // Reset display rotation or mirroring
@@ -396,6 +396,8 @@ class OLEDDisplay : public Stream {
 
     uint16_t drawStringInternal(int16_t xMove, int16_t yMove, const char* text, uint16_t textLength, uint16_t textWidth, bool utf8);
 
+    // Get I2C Speed (to override)
+    virtual uint32_t getI2cFrequency() {return 0; }
 	FontTableLookupFunction fontTableLookupFunction;
 };
 

--- a/src/SH1106Brzo.h
+++ b/src/SH1106Brzo.h
@@ -35,9 +35,9 @@
 #include <brzo_i2c.h>
 
 #if F_CPU == 160000000L
-  #define BRZO_I2C_SPEED 1000
+  #define BRZO_I2C_SPEED 1000000
 #else
-  #define BRZO_I2C_SPEED 800
+  #define BRZO_I2C_SPEED 800000
 #endif
 
 class SH1106Brzo : public OLEDDisplay {
@@ -100,7 +100,8 @@ class SH1106Brzo : public OLEDDisplay {
        uint8_t minBoundXp2H = (minBoundX + 2) & 0x0F;
        uint8_t minBoundXp2L = 0x10 | ((minBoundX + 2) >> 4 );
 
-       brzo_i2c_start_transaction(this->_address, this->_frequency);
+       uint32_t _frequency_khz = this->_frequency / 1000;
+       brzo_i2c_start_transaction(this->_address, _frequency_khz); // brzo_i2c_start_transaction expects kHz
 
        for (y = minBoundY; y <= maxBoundY; y++) {
          sendCommand(0xB0 + y);
@@ -130,7 +131,7 @@ class SH1106Brzo : public OLEDDisplay {
 
     // Get I2C speed
     virtual uint32_t getI2cFrequency() override {
-      return this->_frequency * 1000;
+      return this->_frequency;
     }
 
   private:
@@ -139,7 +140,8 @@ class SH1106Brzo : public OLEDDisplay {
     }
     inline void sendCommand(uint8_t com) __attribute__((always_inline)){
       uint8_t command[2] = {0x80 /* command mode */, com};
-      brzo_i2c_start_transaction(_address, this->_frequency);
+      uint32_t _frequency_khz = this->_frequency / 1000;
+      brzo_i2c_start_transaction(this->_address, _frequency_khz); // brzo_i2c_start_transaction expects kHz
       brzo_i2c_write(command, 2, true);
       brzo_i2c_end_transaction();
     }

--- a/src/SH1106Brzo.h
+++ b/src/SH1106Brzo.h
@@ -47,12 +47,13 @@ class SH1106Brzo : public OLEDDisplay {
       uint8_t             _scl;
 
   public:
-	SH1106Brzo(uint8_t _address, uint8_t _sda, uint8_t _scl, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64) {
+	SH1106Brzo(uint8_t _address, uint8_t _sda, uint8_t _scl, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64, int _frequency = BRZO_I2C_SPEED) {
 		setGeometry(g);
 
       this->_address = _address;
       this->_sda = _sda;
       this->_scl = _scl;
+      this->_frequency = _frequency;
     }
 
     bool connect(){
@@ -98,7 +99,7 @@ class SH1106Brzo : public OLEDDisplay {
        uint8_t minBoundXp2H = (minBoundX + 2) & 0x0F;
        uint8_t minBoundXp2L = 0x10 | ((minBoundX + 2) >> 4 );
 
-       brzo_i2c_start_transaction(this->_address, BRZO_I2C_SPEED);
+       brzo_i2c_start_transaction(this->_address, this->_frequency);
 
        for (y = minBoundY; y <= maxBoundY; y++) {
          sendCommand(0xB0 + y);
@@ -126,13 +127,18 @@ class SH1106Brzo : public OLEDDisplay {
      #endif
     }
 
+    // Get I2C speed
+    virtual uint32_t getI2cFrequency() override {
+      return this->_frequency * 1000;
+    }
+
   private:
 	int getBufferOffset(void) {
 		return 0;
 	}
     inline void sendCommand(uint8_t com) __attribute__((always_inline)){
       uint8_t command[2] = {0x80 /* command mode */, com};
-      brzo_i2c_start_transaction(_address, BRZO_I2C_SPEED);
+      brzo_i2c_start_transaction(_address, this->_frequency);
       brzo_i2c_write(command, 2, true);
       brzo_i2c_end_transaction();
     }

--- a/src/SH1106Brzo.h
+++ b/src/SH1106Brzo.h
@@ -45,6 +45,7 @@ class SH1106Brzo : public OLEDDisplay {
       uint8_t             _address;
       uint8_t             _sda;
       uint8_t             _scl;
+      int                 _frequency;
 
   public:
 	SH1106Brzo(uint8_t _address, uint8_t _sda, uint8_t _scl, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64, int _frequency = BRZO_I2C_SPEED) {
@@ -133,9 +134,9 @@ class SH1106Brzo : public OLEDDisplay {
     }
 
   private:
-	int getBufferOffset(void) {
-		return 0;
-	}
+    int getBufferOffset(void) {
+      return 0;
+    }
     inline void sendCommand(uint8_t com) __attribute__((always_inline)){
       uint8_t command[2] = {0x80 /* command mode */, com};
       brzo_i2c_start_transaction(_address, this->_frequency);

--- a/src/SH1106Wire.h
+++ b/src/SH1106Wire.h
@@ -44,7 +44,9 @@
 #define SH1106_SET_PUMP_MODE 0XAD
 #define SH1106_PUMP_ON 0X8B
 #define SH1106_PUMP_OFF 0X8A
+#ifndef SH1106I2C_FREQUENCY
 #define SH1106I2C_FREQUENCY 700000
+#endif
 //--------------------------------------
 
 class SH1106Wire : public OLEDDisplay {

--- a/src/SH1106Wire.h
+++ b/src/SH1106Wire.h
@@ -203,7 +203,7 @@ class SH1106Wire : public OLEDDisplay {
 
     // Get I2C speed
     virtual uint32_t getI2cFrequency() override {
-      return this->_frequency;
+      return this->_frequency < 0 ? 0U : static_cast<uint32_t>(this->_frequency);
     }
 
   private:

--- a/src/SH1106Wire.h
+++ b/src/SH1106Wire.h
@@ -44,6 +44,7 @@
 #define SH1106_SET_PUMP_MODE 0XAD
 #define SH1106_PUMP_ON 0X8B
 #define SH1106_PUMP_OFF 0X8A
+#define SH1106I2C_FREQUENCY 700000
 //--------------------------------------
 
 class SH1106Wire : public OLEDDisplay {
@@ -72,7 +73,7 @@ class SH1106Wire : public OLEDDisplay {
      * @param _i2cBus on ESP32 with 2 I2C HW buses, I2C_ONE for 1st Bus, I2C_TWO fot 2nd bus, default I2C_ONE
      * @param _frequency for Frequency by default Let's use ~700khz if ESP8266 is in 160Mhz mode, this will be limited to ~400khz if the ESP8266 in 80Mhz mode
      */
-    SH1106Wire(uint8_t _address, int _sda = -1, int _scl = -1, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64, HW_I2C _i2cBus = I2C_ONE, int _frequency = 700000) {
+    SH1106Wire(uint8_t _address, int _sda = -1, int _scl = -1, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64, HW_I2C _i2cBus = I2C_ONE, int _frequency = SH1106I2C_FREQUENCY) {
       setGeometry(g);
 
       this->_address = _address;
@@ -138,7 +139,7 @@ class SH1106Wire : public OLEDDisplay {
         // Calculate the colum offset
         uint8_t minBoundXp2H = (minBoundX + 2) & 0x0F;
         uint8_t minBoundXp2L = 0x10 | ((minBoundX + 2) >> 4 );
-        
+
         if (_subtype == 7) {
           // we have an SH1107
           minBoundXp2H = (minBoundX) & 0x0F;
@@ -196,6 +197,11 @@ class SH1106Wire : public OLEDDisplay {
 
     void setSubtype(uint8_t subtype) {
       _subtype = subtype;
+    }
+
+    // Get I2C speed
+    virtual uint32_t getI2cFrequency() override {
+      return this->_frequency;
     }
 
   private:

--- a/src/SSD1306Brzo.h
+++ b/src/SSD1306Brzo.h
@@ -47,12 +47,13 @@ class SSD1306Brzo : public OLEDDisplay {
       uint8_t             _scl;
 
   public:
-    SSD1306Brzo(uint8_t _address, uint8_t _sda, uint8_t _scl, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64) {
+    SSD1306Brzo(uint8_t _address, uint8_t _sda, uint8_t _scl, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64, int _frequency = BRZO_I2C_SPEED) {
       setGeometry(g);
 
       this->_address = _address;
       this->_sda = _sda;
       this->_scl = _scl;
+      this->_frequency = _frequency;
     }
 
     bool connect(){
@@ -107,7 +108,7 @@ class SSD1306Brzo : public OLEDDisplay {
 
        uint8_t sendBuffer[buflen];
        sendBuffer[0] = 0x40;
-       brzo_i2c_start_transaction(this->_address, BRZO_I2C_SPEED);
+       brzo_i2c_start_transaction(this->_address, this->_frequency);
        for (y = minBoundY; y <= maxBoundY; y++) {
            for (x = minBoundX; x <= maxBoundX; x++) {
                k++;
@@ -137,7 +138,7 @@ class SSD1306Brzo : public OLEDDisplay {
        uint8_t sendBuffer[buflen];
        sendBuffer[0] = 0x40;
 
-       brzo_i2c_start_transaction(this->_address, BRZO_I2C_SPEED);
+       brzo_i2c_start_transaction(this->_address, this->_frequency);
 
        for (uint16_t i=0; i<displayBufferSize; i++) {
          for (uint8_t x=1; x<buflen; x++) {
@@ -152,13 +153,19 @@ class SSD1306Brzo : public OLEDDisplay {
      #endif
     }
 
+
+    // Get I2C speed
+    virtual uint32_t getI2cFrequency() override {
+      return this->_frequency * 1000;
+    }
+
   private:
 	int getBufferOffset(void) {
 		return 0;
 	}
     inline void sendCommand(uint8_t com) __attribute__((always_inline)){
       uint8_t command[2] = {0x80 /* command mode */, com};
-      brzo_i2c_start_transaction(_address, BRZO_I2C_SPEED);
+      brzo_i2c_start_transaction(this->_address, this->_frequency);
       brzo_i2c_write(command, 2, true);
       brzo_i2c_end_transaction();
     }

--- a/src/SSD1306Brzo.h
+++ b/src/SSD1306Brzo.h
@@ -35,9 +35,9 @@
 #include <brzo_i2c.h>
 
 #if F_CPU == 160000000L
-  #define BRZO_I2C_SPEED 1000
+  #define BRZO_I2C_SPEED 1000000
 #else
-  #define BRZO_I2C_SPEED 800
+  #define BRZO_I2C_SPEED 800000
 #endif
 
 class SSD1306Brzo : public OLEDDisplay {
@@ -139,7 +139,8 @@ class SSD1306Brzo : public OLEDDisplay {
        uint8_t sendBuffer[buflen];
        sendBuffer[0] = 0x40;
 
-       brzo_i2c_start_transaction(this->_address, this->_frequency);
+       uint32_t _frequency_khz = this->_frequency / 1000;
+       brzo_i2c_start_transaction(this->_address, _frequency_khz); // brzo_i2c_start_transaction expects kHz
 
        for (uint16_t i=0; i<displayBufferSize; i++) {
          for (uint8_t x=1; x<buflen; x++) {
@@ -157,7 +158,7 @@ class SSD1306Brzo : public OLEDDisplay {
 
     // Get I2C speed
     virtual uint32_t getI2cFrequency() override {
-      return this->_frequency * 1000;
+      return this->_frequency;
     }
 
   private:
@@ -166,7 +167,8 @@ class SSD1306Brzo : public OLEDDisplay {
 	}
     inline void sendCommand(uint8_t com) __attribute__((always_inline)){
       uint8_t command[2] = {0x80 /* command mode */, com};
-      brzo_i2c_start_transaction(this->_address, this->_frequency);
+      uint32_t _frequency_khz = this->_frequency / 1000;
+      brzo_i2c_start_transaction(this->_address, _frequency_khz); // brzo_i2c_start_transaction expects kHz
       brzo_i2c_write(command, 2, true);
       brzo_i2c_end_transaction();
     }

--- a/src/SSD1306Brzo.h
+++ b/src/SSD1306Brzo.h
@@ -45,6 +45,7 @@ class SSD1306Brzo : public OLEDDisplay {
       uint8_t             _address;
       uint8_t             _sda;
       uint8_t             _scl;
+      int                 _frequency;
 
   public:
     SSD1306Brzo(uint8_t _address, uint8_t _sda, uint8_t _scl, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64, int _frequency = BRZO_I2C_SPEED) {

--- a/src/SSD1306I2C.h
+++ b/src/SSD1306I2C.h
@@ -61,7 +61,8 @@ public:
     }
 
     bool connect() {
-	    _i2c->frequency(this->_frequency);
+      if(this->_frequency != -1)
+	      _i2c->frequency(this->_frequency);
       return true;
     }
 
@@ -136,7 +137,7 @@ public:
 
     // Get I2C speed
     virtual uint32_t getI2cFrequency() override {
-      return this->_frequency;
+      return this->_frequency < 0 ? 0U : static_cast<uint32_t>(this->_frequency);
     }
 
 private:

--- a/src/SSD1306I2C.h
+++ b/src/SSD1306I2C.h
@@ -57,7 +57,7 @@ public:
       this->_sda = _sda;
       this->_scl = _scl;
       this->_frequency = _frequency;
-	  _i2c = new I2C(_sda, _scl);
+	    _i2c = new I2C(_sda, _scl);
     }
 
     bool connect() {
@@ -154,6 +154,7 @@ private:
 	uint8_t             _address;
 	PinName             _sda;
 	PinName             _scl;
+  int                 _frequency;
 	I2C *_i2c;
 };
 

--- a/src/SSD1306I2C.h
+++ b/src/SSD1306I2C.h
@@ -30,6 +30,13 @@
 #ifndef SSD1306I2C_h
 #define SSD1306I2C_h
 
+// mbed supports 100k and 400k some device maybe 1000k
+#ifdef TARGET_STM32L4
+#define SSD1306I2C_FREQUENCY 1000000
+#else
+#define SSD1306I2C_FREQUENCY 400000
+#endif
+
 
 #ifdef __MBED__
 
@@ -42,22 +49,18 @@
 
 class SSD1306I2C : public OLEDDisplay {
 public:
-    SSD1306I2C(uint8_t _address, PinName _sda, PinName _scl, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64) {
+    SSD1306I2C(uint8_t _address, PinName _sda, PinName _scl, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64, int _frequency = SSD1306I2C_FREQUENCY) {
       setGeometry(g);
 
       this->_address = _address << 1;  // convert from 7 to 8 bit for mbed.
       this->_sda = _sda;
       this->_scl = _scl;
+      this->_frequency = _frequency;
 	  _i2c = new I2C(_sda, _scl);
     }
 
     bool connect() {
-		// mbed supports 100k and 400k some device maybe 1000k
-#ifdef TARGET_STM32L4
-	  _i2c->frequency(1000000);
-#else
-	  _i2c->frequency(400000);
-#endif
+	    _i2c->frequency(this->_frequency);
       return true;
     }
 
@@ -104,7 +107,7 @@ public:
         for (y = minBoundY; y <= maxBoundY; y++) {
 			uint8_t *start = &buffer[(minBoundX + y * this->width())-1];
 			uint8_t save = *start;
-			
+
 			*start = 0x40; // control
 			_i2c->write(_address, (char *)start, (maxBoundX-minBoundX) + 1 + 1);
 			*start = save;
@@ -127,6 +130,12 @@ public:
 		buffer[-1] = 0x40; // control
 		_i2c->write(_address, (char *)&buffer[-1], displayBufferSize + 1);
 #endif
+    }
+
+
+    // Get I2C speed
+    virtual uint32_t getI2cFrequency() override {
+      return this->_frequency;
     }
 
 private:

--- a/src/SSD1306I2C.h
+++ b/src/SSD1306I2C.h
@@ -33,12 +33,13 @@
 #ifdef __MBED__
 
 // mbed supports 100k and 400k some device maybe 1000k
+#ifndef SSD1306I2C_FREQUENCY
 #ifdef TARGET_STM32L4
 #define SSD1306I2C_FREQUENCY 1000000
 #else
 #define SSD1306I2C_FREQUENCY 400000
 #endif
-
+#endif
 
 #include "OLEDDisplay.h"
 #include <mbed.h>

--- a/src/SSD1306I2C.h
+++ b/src/SSD1306I2C.h
@@ -30,6 +30,8 @@
 #ifndef SSD1306I2C_h
 #define SSD1306I2C_h
 
+#ifdef __MBED__
+
 // mbed supports 100k and 400k some device maybe 1000k
 #ifdef TARGET_STM32L4
 #define SSD1306I2C_FREQUENCY 1000000
@@ -38,13 +40,11 @@
 #endif
 
 
-#ifdef __MBED__
-
 #include "OLEDDisplay.h"
 #include <mbed.h>
 
 #ifndef UINT8_MAX
- #define UINT8_MAX 0xff
+#define UINT8_MAX 0xff
 #endif
 
 class SSD1306I2C : public OLEDDisplay {

--- a/src/SSD1306Wire.h
+++ b/src/SSD1306Wire.h
@@ -44,6 +44,7 @@
 #else
 #define I2C_MAX_TRANSFER_BYTE 17
 #endif
+#define SSD1306I2C_FREQUENCY 700000
 //--------------------------------------
 
 class SSD1306Wire : public OLEDDisplay {
@@ -73,7 +74,7 @@ class SSD1306Wire : public OLEDDisplay {
      * @param _i2cBus on ESP32 with 2 I2C HW buses, I2C_ONE for 1st Bus, I2C_TWO fot 2nd bus, default I2C_ONE
      * @param _frequency for Frequency by default Let's use ~700khz if ESP8266 is in 160Mhz mode, this will be limited to ~400khz if the ESP8266 in 80Mhz mode
      */
-    SSD1306Wire(uint8_t _address, int _sda = -1, int _scl = -1, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64, HW_I2C _i2cBus = I2C_ONE, int _frequency = 700000) {
+    SSD1306Wire(uint8_t _address, int _sda = -1, int _scl = -1, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64, HW_I2C _i2cBus = I2C_ONE, int _frequency = SSD1306I2C_FREQUENCY) {
       setGeometry(g);
 
       this->_address = _address;
@@ -199,6 +200,11 @@ class SSD1306Wire : public OLEDDisplay {
 
     void setI2cAutoInit(bool doI2cAutoInit) {
       _doI2cAutoInit = doI2cAutoInit;
+    }
+
+    // Get I2C speed
+    virtual uint32_t getI2cFrequency() override {
+      return this->_frequency;
     }
 
   private:

--- a/src/SSD1306Wire.h
+++ b/src/SSD1306Wire.h
@@ -44,7 +44,7 @@
 #else
 #define I2C_MAX_TRANSFER_BYTE 17
 #endif
-#define SSD1306I2C_FREQUENCY 700000
+#define SSD1306_WIRE_I2C_FREQUENCY 700000
 //--------------------------------------
 
 class SSD1306Wire : public OLEDDisplay {
@@ -74,7 +74,7 @@ class SSD1306Wire : public OLEDDisplay {
      * @param _i2cBus on ESP32 with 2 I2C HW buses, I2C_ONE for 1st Bus, I2C_TWO fot 2nd bus, default I2C_ONE
      * @param _frequency for Frequency by default Let's use ~700khz if ESP8266 is in 160Mhz mode, this will be limited to ~400khz if the ESP8266 in 80Mhz mode
      */
-    SSD1306Wire(uint8_t _address, int _sda = -1, int _scl = -1, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64, HW_I2C _i2cBus = I2C_ONE, int _frequency = SSD1306I2C_FREQUENCY) {
+    SSD1306Wire(uint8_t _address, int _sda = -1, int _scl = -1, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64, HW_I2C _i2cBus = I2C_ONE, int _frequency = SSD1306_WIRE_I2C_FREQUENCY) {
       setGeometry(g);
 
       this->_address = _address;

--- a/src/SSD1306Wire.h
+++ b/src/SSD1306Wire.h
@@ -44,7 +44,9 @@
 #else
 #define I2C_MAX_TRANSFER_BYTE 17
 #endif
+#ifndef SSD1306_WIRE_I2C_FREQUENCY
 #define SSD1306_WIRE_I2C_FREQUENCY 700000
+#endif
 //--------------------------------------
 
 class SSD1306Wire : public OLEDDisplay {

--- a/src/SSD1306Wire.h
+++ b/src/SSD1306Wire.h
@@ -206,7 +206,7 @@ class SSD1306Wire : public OLEDDisplay {
 
     // Get I2C speed
     virtual uint32_t getI2cFrequency() override {
-      return this->_frequency;
+      return this->_frequency < 0 ? 0U : static_cast<uint32_t>(this->_frequency);
     }
 
   private:

--- a/src/ST7567Wire.h
+++ b/src/ST7567Wire.h
@@ -68,7 +68,8 @@ class ST7567Wire : public OLEDDisplay
 #endif
         // Let's use ~700khz if ESP8266 is in 160Mhz mode
         // this will be limited to ~400khz if the ESP8266 in 80Mhz mode.
-        Wire.setClock(this->_frequency);
+        if(this->_frequency != -1)
+            Wire.setClock(this->_frequency);
         return true;
     }
 
@@ -168,7 +169,7 @@ class ST7567Wire : public OLEDDisplay
 
     // Get I2C speed
     virtual uint32_t getI2cFrequency() override {
-      return this->_frequency;
+      return this->_frequency < 0 ? 0U : static_cast<uint32_t>(this->_frequency);
     }
 
   protected:

--- a/src/ST7567Wire.h
+++ b/src/ST7567Wire.h
@@ -34,8 +34,9 @@
 #include "OLEDDisplay.h"
 #include <Wire.h>
 
+#ifndef ST7567I2C_FREQUENCY
 #define ST7567I2C_FREQUENCY 700000
-
+#endif
 //--------------------------------------
 
 class ST7567Wire : public OLEDDisplay

--- a/src/ST7567Wire.h
+++ b/src/ST7567Wire.h
@@ -42,11 +42,11 @@
 class ST7567Wire : public OLEDDisplay
 {
   private:
-    uint8_t _address;
-    int _sda;
-    int _scl;
-    boolean _doI2cAutoInit = false;
-    int _frequency;
+    uint8_t             _address;
+    int                 _sda;
+    int                 _scl;
+    boolean             _doI2cAutoInit = false;
+    int                 _frequency;
 
   public:
     ST7567Wire(uint8_t _address, int _sda = -1, int _scl = -1, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64, int _frequency = ST7567I2C_FREQUENCY)

--- a/src/ST7567Wire.h
+++ b/src/ST7567Wire.h
@@ -34,6 +34,8 @@
 #include "OLEDDisplay.h"
 #include <Wire.h>
 
+#define ST7567I2C_FREQUENCY 700000
+
 //--------------------------------------
 
 class ST7567Wire : public OLEDDisplay
@@ -43,13 +45,15 @@ class ST7567Wire : public OLEDDisplay
     int _sda;
     int _scl;
     boolean _doI2cAutoInit = false;
+    int _frequency;
 
   public:
-    ST7567Wire(uint8_t _address, int _sda = -1, int _scl = -1, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64)
+    ST7567Wire(uint8_t _address, int _sda = -1, int _scl = -1, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64, int _frequency = ST7567I2C_FREQUENCY)
     {
         this->_address = _address;
         this->_sda = _sda;
         this->_scl = _scl;
+        this->_frequency = _frequency;
     }
 
     bool connect()
@@ -63,7 +67,7 @@ class ST7567Wire : public OLEDDisplay
 #endif
         // Let's use ~700khz if ESP8266 is in 160Mhz mode
         // this will be limited to ~400khz if the ESP8266 in 80Mhz mode.
-        Wire.setClock(700000);
+        Wire.setClock(this->_frequency);
         return true;
     }
 
@@ -160,6 +164,11 @@ class ST7567Wire : public OLEDDisplay
     }
 
     void setI2cAutoInit(boolean doI2cAutoInit) { _doI2cAutoInit = doI2cAutoInit; }
+
+    // Get I2C speed
+    virtual uint32_t getI2cFrequency() override {
+      return this->_frequency;
+    }
 
   protected:
     // Send all the init commands


### PR DESCRIPTION
This PR supports the effort in https://github.com/meshtastic/firmware/pull/9898 to be able to have better control of the I2C speed settings.

The PR adds a couple of improvements to:

* Unify classes adding I2C frequency defines for I2C screens
* Add getI2cFrequency method